### PR TITLE
Avoid setting timer to null before calling _resetTimer

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -132,8 +132,8 @@ const WallpaperChangerEntry = new Lang.Class({
       this.timer = GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT,
         TIMER.toSeconds(),
         Lang.bind(this, function () {
-          this._nextWallpaper();
           this.timer = null;
+          this._nextWallpaper();
           return false;
         })
       );


### PR DESCRIPTION
When `_resetTimer` is invoked, the following events occur:

1) If there is an existing timer, then it is removed via `GLib.Source.remove`
2) If the `TIMER` is currently running, then a new timer is created and assigned to `timer` using the current settings of `TIMER`
3) Once the `timer` triggers, then `_nextWallpaper` is invoked...
3a) ...which invokes `_resetTimer` again...
3b) ...which assigns `timer` to a new instance...
4) After `_nextWallpaper` completes (having set `timer` to a new instance), then `timer` is set to `null`.

Changing a setting afterward will again invoke `_resetTimer`, but `timer` will be null, so any current timers are not actually removed via `GLib.Source.remove`.